### PR TITLE
Add live reloading to some options, email fix

### DIFF
--- a/jellyfin_accounts/data/config-base.json
+++ b/jellyfin_accounts/data/config-base.json
@@ -87,7 +87,7 @@
         },
         "jellyfin_login": {
             "name": "Use Jellyfin for authentication",
-            "required": true,
+            "required": false,
             "requires_restart": true,
             "type": "bool",
             "value": true,
@@ -122,7 +122,7 @@
         },
         "debug": {
             "name": "Debug logging",
-            "required": true,
+            "required": false,
             "requires_restart": true,
             "type": "bool",
             "value": false
@@ -130,7 +130,7 @@
         "contact_message": {
             "name": "Contact message",
             "required": false,
-            "requires_restart": false,
+            "requires_restart": true,
             "type": "text",
             "value": "Need help? contact me.",
             "description": "Displayed at bottom of all pages except admin"
@@ -138,7 +138,7 @@
         "help_message": {
             "name": "Help message",
             "required": false,
-            "requires_restart": false,
+            "requires_restart": true,
             "type": "text",
             "value": "Enter your details to create an account.",
             "description": "Display at top of invite form."
@@ -146,7 +146,7 @@
         "success_message": {
             "name": "Success message",
             "required": false,
-            "requires_restart": false,
+            "requires_restart": true,
             "type": "text",
             "value": "Your account has been created. Click below to continue to Jellyfin.",
             "description": "Displayed when a user creates an account"
@@ -159,7 +159,7 @@
         },
         "enabled": {
             "name": "Enabled",
-            "required": true,
+            "required": false,
             "requires_restart": true,
             "type": "bool",
             "value": true
@@ -195,6 +195,7 @@
         "special": {
             "name": "Minimum number of special characters",
             "requires_restart": true,
+            "depends_true": "enabled",
             "type": "text",
             "value": "0"
         }
@@ -277,7 +278,7 @@
         },
         "enabled": {
             "name": "Enabled",
-            "required": true,
+            "required": false,
             "requires_restart": true,
             "type": "bool",
             "value": true,
@@ -327,7 +328,7 @@
         },
         "enabled": {
             "name": "Enabled",
-            "required": true,
+            "required": false,
             "requires_restart": true,
             "type": "bool",
             "value": true

--- a/jellyfin_accounts/data/static/admin.js
+++ b/jellyfin_accounts/data/static/admin.js
@@ -498,6 +498,9 @@ document.getElementById('openSettings').onclick = function () {
                                 entryName += ' <sup class="text-danger">*</sup>';
                                 required = true;
                             };
+                            if (config[section][entry]['requires_restart']) {
+                                entryName += ' <sup class="text-danger">R</sup>';
+                            };
                             if (config[section][entry].hasOwnProperty('description')) {
                                 var tooltip = `
                                 <a class="text-muted" href="#" data-toggle="tooltip" data-placement="right" title="${config[section][entry]['description']}"><i class="fa fa-question-circle-o"></i></a>
@@ -505,15 +508,12 @@ document.getElementById('openSettings').onclick = function () {
                                 entryName += ' ';
                                 entryName += tooltip;
                             };
-                            // if (config[section][entry]['requires_restart']) {
-                            //     entryName += ' <sup class="text-danger">R</sup>';
-                            // };
                             var entryValue = config[section][entry]['value'];
                             var entryType = config[section][entry]['type'];
                             var entryGroup = document.createElement('div');
                             if (entryType == 'bool') {
                                 entryGroup.classList.add('form-check');
-                                if (entryValue) {
+                                if (entryValue.toString() == 'true') {
                                     var checked = true;
                                 } else {
                                     var checked = false;
@@ -604,8 +604,8 @@ function sendConfig(modalId) {
             xhr.setRequestHeader("Authorization", "Basic " + btoa(window.token + ":"));
         },
         success: function() {
+            $('#' + modalId).modal('hide');
             if (modalId != 'settingsMenu') {
-                $('#' + modalId).modal('hide');
                 $('#settingsMenu').modal('hide');
             };
         },
@@ -618,13 +618,11 @@ function sendConfig(modalId) {
             footer.appendChild(alert);
         },
     });
-    // placeholder
 };
 
 document.getElementById('settingsSave').onclick = function() {
     modifiedConfig = {};
-    // Live config changes have not yet been implemented, so restart always required.
-    // var restart_setting_changed = false;
+    var restart_setting_changed = false;
     var settings_changed = false;
     
     for (var section of Object.keys(config)) {
@@ -643,23 +641,24 @@ document.getElementById('settingsSave').onclick = function() {
                     };
                     modifiedConfig[section][entry] = value;
                     settings_changed = true;
-                    // if (config[section][entry]['requires_restart']) {
-                    //     restart_setting_changed = true;
-                    // };
+                    if (config[section][entry]['requires_restart']) {
+                        restart_setting_changed = true;
+                    };
                 };
             };
         };
     };
     // if (restart_setting_changed) {
-    if (settings_changed) {
+    if (restart_setting_changed) {
         document.getElementById('applyRestarts').onclick = function(){sendConfig('restartModal');};
         $('#settingsMenu').modal('hide');
         $('#restartModal').modal({
             backdrop: 'static',
             show: true
         });
+    } else if (settings_changed) {
+        sendConfig('settingsMenu');
     } else {
-    //    sendConfig('settingsMenu');
         $('#settingsMenu').modal('hide');
     };
 };

--- a/jellyfin_accounts/data/templates/admin.html
+++ b/jellyfin_accounts/data/templates/admin.html
@@ -93,7 +93,7 @@
                     </div>
                     <div class="modal-body">
                         <ul class="list-group list-group-flush">
-                            <p>Note: <sup class="text-danger">*</sup> Indicates required field.</p>
+                            <p>Note: <sup class="text-danger">*</sup> Indicates required field, <sup class="text-danger">R</sup> Indicates changes require a restart.</p>
                             <button type="button" class="list-group-item list-group-item-action" id="openUsers">
                             Users <i class="fa fa-user"></i>
                             </button>
@@ -160,7 +160,7 @@
                         <h5 class="modal-title">Warning</h5>
                     </div>
                     <div class="modal-body">
-                        <p>A restart is needed to apply settings. This must be done manually. Apply now?</p>
+                        <p>A restart is needed to apply some settings. This must be done manually. Apply now?</p>
                     </div>
                     <div class="modal-footer">
                         <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>

--- a/jellyfin_accounts/web.py
+++ b/jellyfin_accounts/web.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 from flask import Flask, send_from_directory, render_template
-from jellyfin_accounts import config, app, g, css, data_store
+
+from jellyfin_accounts import app, g, css, data_store
 from jellyfin_accounts import web_log as log
-from jellyfin_accounts.web_api import checkInvite, validator
+from jellyfin_accounts.web_api import config, checkInvite, validator
 
 
 @app.errorhandler(404)

--- a/jellyfin_accounts/web_api.py
+++ b/jellyfin_accounts/web_api.py
@@ -7,6 +7,8 @@ import time
 from jellyfin_accounts import (
     config,
     config_path,
+    load_config,
+    data_dir,
     app,
     g,
     data_store,
@@ -326,6 +328,7 @@ def setDefaults():
 @app.route("/modifyConfig", methods=["POST"])
 @auth.login_required
 def modifyConfig():
+    global config
     log.info("Config modification requested")
     data = request.get_json()
     temp_config = configparser.RawConfigParser(
@@ -344,7 +347,8 @@ def modifyConfig():
                     log.debug(f"{section}/{item} does not exist in config")
     with open(config_path, "w") as config_file:
         temp_config.write(config_file)
-    log.info("Config written. Restart is needed to load settings.")
+    config = load_config(config_path, data_dir)
+    log.info("Config written. Restart may be needed to load settings.")
     return resp()
 
 
@@ -361,7 +365,7 @@ def getConfig():
     log.debug("Config requested")
     with open(config_base_path, "r") as f:
         config_base = json.load(f)
-    config.read(config_path)
+    # config.read(config_path)
     response_config = config_base
     for section in config_base:
         for entry in config_base[section]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jellyfin-accounts"
-version = "0.2.5"
+version = "0.2.6"
 readme = "README.md"
 description = "A simple account management system for Jellyfin"
 authors = ["Harvey Tindall <harveyltindall@gmail.com>"]


### PR DESCRIPTION
live reloading was intended for previous release, but needed some
tweaking. Settings that still require a restart are marked with an R.
Fixed issue where default values weren't being filled in on reload of
config that broke emails if settings were changed at all.